### PR TITLE
Update support for Gatsby 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "font-awesome"
   ],
   "peerDependencies": {
-    "gatsby": "^3.0.0",
+    "gatsby": "^4.0.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.0"
   },
   "author": "Johnny Zabala <jzabala.s@gmail.com>",


### PR DESCRIPTION
This plugin blocks upgrades to Gatsby 4.0